### PR TITLE
Make backend/net coding systems match up by default

### DIFF
--- a/elein.el
+++ b/elein.el
@@ -65,6 +65,16 @@
   :type 'string
   :group 'elein)
 
+(defcustom elein-slime-net-coding-system 'utf-8-unix
+  "Coding system used for slime network connections.
+Should match any :encoding specified in `elein-swank-options'.
+See also `slime-net-valid-coding-systems'."
+  :type (cons 'choice
+              (mapcar (lambda (x)
+                        (list 'const (car x)))
+                      slime-net-valid-coding-systems))
+  :group 'elein)
+
 (defun elein-project-root ()
   "Look for project.clj file to find project root."
   (locate-dominating-file default-directory "project.clj"))
@@ -138,7 +148,7 @@ show output and burry the given BUFFER."
 
   (when (string-match "Connection opened on \\(local\\|127.0.0.1\\) port +\\([0-9]+\\)" output)
     (slime-set-inferior-process
-     (slime-connect "localhost" (string-to-number (match-string 2 output)))
+     (slime-connect "localhost" (string-to-number (match-string 2 output)) elein-slime-net-coding-system)
      process)
     (set-process-filter process nil)))
 


### PR DESCRIPTION
Given the default "lein swank" :encoding options (utf-8), and the default value of
'slime-net-coding-system (iso-latin), users are prone to encountering errors such as this one:

https://github.com/technomancy/swank-clojure/issues/57

Documentation is scarce, so in this commit I've tweaked elein such that everything
Just Works out of the box. That is, by simply installing the Marmalade/ELPA packages for
clojure-mode, slime and elein, "lein-swank" will use the correct back-end and net
coding systems without any further customization.
