### PR TITLE
Don't require 'slime-net-valid-coding-systems to be defined when loading elein

### DIFF
--- a/elein.el
+++ b/elein.el
@@ -69,10 +69,7 @@
   "Coding system used for slime network connections.
 Should match any :encoding specified in `elein-swank-options'.
 See also `slime-net-valid-coding-systems'."
-  :type (cons 'choice
-              (mapcar (lambda (x)
-                        (list 'const (car x)))
-                      slime-net-valid-coding-systems))
+  :type 'symbol
   :group 'elein)
 
 (defun elein-project-root ()


### PR DESCRIPTION
Remco -- I have to apologise. I found that my previous changes make `elein` trigger an error if it is loaded before slime, because the `defcustom` references `slime-net-valid-coding-systems`.

The fix would be to either `(require 'slime)` or to change the `:type` to `'symbol`. This pull request makes the latter change.

Once again, sorry.

-Steve
