### PR TITLE
Remove eval-when-compile for using cl functions

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,22 @@
+elein.el -- running leiningen commands from emacs
+
+Provides support for running leiningen commands like swank and test
+from emacs.
+
+Copyright (C) 2010 R.W van 't Veer
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GNU Emacs; see the file COPYING.  If not, write to the
+Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+Boston, MA 02110-1301, USA.
+

--- a/elein.el
+++ b/elein.el
@@ -114,6 +114,7 @@
           elein-swank-host
           elein-swank-options))
 
+;;;###autoload
 (defun elein-swank ()
   "Launch lein swank and connect slime to it."
   (interactive)
@@ -130,6 +131,7 @@
                             (set-process-filter process nil))))
     (message "Starting swank..")))
 
+;;;###autoload
 (defun elein-kill-swank ()
   "Kill swank process started by lein swank."
   (interactive)
@@ -143,17 +145,20 @@
           (decf timeout)))
       (ignore-errors (kill-buffer "*elein-swank*")))))
 
+;;;###autoload
 (defun elein-reswank ()
   "Kill current lisp, restart lein swank and connect slime to it."
   (interactive)
   (elein-kill-swank)
   (elein-swank))
 
+;;;###autoload
 (defun elein-run-cmd (args)
   "Run 'lein ARGS' using `compile' in the project root directory."
   (interactive "sArguments: ")
   (elein-in-project-root (compile (concat elein-lein " " args))))
 
+;;;###autoload
 (defun elein-run-task (task)
   "Run 'lein TASK' using `compile' in the project root directory."
   (interactive (list (completing-read "Task: " (elein-list-tasks))))

--- a/elein.el
+++ b/elein.el
@@ -84,13 +84,17 @@
 (defun elein-swank ()
   "Launch lein swank and connect slime to it."
   (interactive)
-  (elein-in-project-root (shell-command "lein swank&" "*elein-swank*"))
-  (set-process-filter (get-buffer-process "*elein-swank*")
-                      (lambda (process output)
-                        (when (string-match "Connection opened on local port +\\([0-9]+\\)" output)
-                          (slime-connect "localhost" (match-string 1 output))
-                          (set-process-filter process nil))))
-  (message "Starting swank.."))
+  (let ((buffer (get-buffer-create  "*elein-swank*")))
+    (flet ((display-buffer (buffer-or-name &optional not-this-window frame) nil))
+      (bury-buffer buffer)
+      (elein-in-project-root (shell-command "lein swank&" buffer)))
+
+    (set-process-filter (get-buffer-process buffer)
+                        (lambda (process output)
+                          (when (string-match "Connection opened on local port +\\([0-9]+\\)" output)
+                            (slime-connect "localhost" (match-string 1 output))
+                            (set-process-filter process nil))))
+    (message "Starting swank..")))
 
 (defun elein-kill-swank ()
   "Kill swank process started by lein swank."

--- a/elein.el
+++ b/elein.el
@@ -65,6 +65,16 @@
   :type 'string
   :group 'elein)
 
+(defcustom elein-slime-net-coding-system 'utf-8-unix
+  "Coding system used for slime network connections.
+Should match any :encoding specified in `elein-swank-options'.
+See also `slime-net-valid-coding-systems'."
+  :type (cons 'choice
+              (mapcar (lambda (x)
+                        (list 'const (car x)))
+                      slime-net-valid-coding-systems))
+  :group 'elein)
+
 (defun elein-project-root ()
   "Look for project.clj file to find project root."
   (locate-dominating-file default-directory "project.clj"))
@@ -138,7 +148,7 @@ show output and burry the given BUFFER."
 
   (when (string-match "Connection opened on \\(local\\|127.0.0.1\\) port +\\([0-9]+\\)" output)
     (slime-set-inferior-process
-     (slime-connect "localhost" (string-to-number (match-string 2 output)))
+     (slime-connect "localhost" (string-to-number (match-string 2 output)) elein-slime-net-coding-system)
      process)
     (set-process-filter process nil)))
 

--- a/elein.el
+++ b/elein.el
@@ -138,7 +138,7 @@ show output and burry the given BUFFER."
 
   (when (string-match "Connection opened on local port +\\([0-9]+\\)" output)
     (slime-set-inferior-process
-     (slime-connect "localhost" (match-string 1 output))
+     (slime-connect "localhost" (string-to-number (match-string 1 output)))
      process)
     (set-process-filter process nil)))
 

--- a/elein.el
+++ b/elein.el
@@ -136,9 +136,9 @@ show output and burry the given BUFFER."
   "Swank process filter to launch `slime-connect' when process is ready."
   (with-current-buffer elein-swank-buffer-name (insert output))
 
-  (when (string-match "Connection opened on local port +\\([0-9]+\\)" output)
+  (when (string-match "Connection opened on \\(local\\|127.0.0.1\\) port +\\([0-9]+\\)" output)
     (slime-set-inferior-process
-     (slime-connect "localhost" (string-to-number (match-string 1 output)))
+     (slime-connect "localhost" (string-to-number (match-string 2 output)))
      process)
     (set-process-filter process nil)))
 

--- a/elein.el
+++ b/elein.el
@@ -124,6 +124,7 @@
 
     (set-process-filter (get-buffer-process buffer)
                         (lambda (process output)
+                          (with-current-buffer elein-swank-buffer-name (insert output))
                           (when (string-match "Connection opened on local port +\\([0-9]+\\)" output)
                             (slime-connect "localhost" (match-string 1 output))
                             (set-process-filter process nil))))

--- a/elein.el
+++ b/elein.el
@@ -1,10 +1,12 @@
-;;; elein.el -- running leiningen commands from emacs
+;;; elein.el --- running leiningen commands from emacs
 
-;; Copyright (C) 2010 R.W van 't Veer
+;; Copyright (C) 2010, 2011 R.W van 't Veer
 
 ;; Author: R.W. van 't Veer
 ;; Created: 2 Aug 2010
 ;; Keywords: tools processes
+;; Version: 0.1
+;; URL: https://github.com/remvee/elein
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
@@ -26,7 +28,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(eval-when-compile (require 'cl))
 
 (defgroup elein nil
   "running leiningen commands from emacs"

--- a/elein.el
+++ b/elein.el
@@ -5,7 +5,7 @@
 ;; Author: R.W. van 't Veer
 ;; Created: 2 Aug 2010
 ;; Keywords: tools processes
-;; Version: 0.1
+;; Version: 0.2
 ;; URL: https://github.com/remvee/elein
 
 ;; This program is free software; you can redistribute it and/or

--- a/elein.el
+++ b/elein.el
@@ -115,10 +115,15 @@
   (elein-kill-swank)
   (elein-swank))
 
+(defun elein-run-cmd (args)
+  "Run 'lein ARGS' using `compile' in the project root directory."
+  (interactive "sArguments: ")
+  (elein-in-project-root (compile (concat "lein " args))))
+
 (defun elein-run-task (task)
   "Run 'lein TASK' using `compile' in the project root directory."
   (interactive (list (completing-read "Task: " (elein-list-tasks))))
-  (elein-in-project-root (compile (concat "lein " task))))
+  (elein-run-cmd task))
 
 (defmacro elein-defun-run-task (task)
   "Define shortcut function for `elein-run-task' with argument TASK."

--- a/elein.el
+++ b/elein.el
@@ -5,7 +5,7 @@
 ;; Author: R.W. van 't Veer
 ;; Created: 2 Aug 2010
 ;; Keywords: tools processes
-;; Version: 0.2.1
+;; Version: 0.2.2
 ;; URL: https://github.com/remvee/elein
 
 ;; This program is free software; you can redistribute it and/or

--- a/elein.el
+++ b/elein.el
@@ -28,7 +28,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(require 'cl)
 
 (defgroup elein nil
   "running leiningen commands from emacs"

--- a/elein.el
+++ b/elein.el
@@ -1,0 +1,114 @@
+;;; elein.el -- running leiningen commands from emacs
+
+;; Copyright (C) 2010 R.W van 't Veer
+
+;; Author: R.W. van 't Veer
+;; Created: 2 Aug 2010
+;; Keywords: tools processes
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+;; 
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;; 
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+;; Provides support for running leiningen commands like swank and test.
+
+;;; Code:
+
+(require 'cl)
+
+(defgroup elein nil
+  "running leiningen commands from emacs"
+  :prefix "elein-"
+  :group 'applications)
+
+(defcustom elein-swank-timeout
+  10
+  "Number of seconds for swank to come up."
+  :type 'number
+  :group 'elein)
+
+(defun elein-project-root ()
+  "Look for project.clj file to find project root."
+  (let ((cwd default-directory)
+        (found nil)
+        (max 10))
+    (while (and (not found) (> max 0))
+      (if (file-exists-p (concat cwd "project.clj"))
+        (setq found cwd)
+        (setq cwd (concat cwd "../") max (- max 1))))
+    (and found (expand-file-name found))))
+
+(defmacro elein-in-project-root (body)
+  "Wrap BODY to make `default-directory' the project root."
+  (let ((dir (gensym)))
+    `(let ((,dir (elein-project-root)))
+       (if ,dir
+         (let ((default-directory ,dir)) ,body)
+         (error "No leiningen project root found")))))
+
+(defun elein-swank ()
+  "Lauch lein swank and connect slime to it."
+  (interactive)
+  (elein-in-project-root (shell-command "lein swank&" "*elein-swank*"))
+  (with-current-buffer "*elein-swank*"
+    (let ((timeout elein-swank-timeout))
+      (while (and (> timeout 0)
+                  (not (progn (goto-char (point-min))
+                              (search-forward-regexp "Connection opened on local port +\\([0-9]+\\)" nil t)))
+                  (not (progn (goto-char (point-min))
+                              (search-forward "No project.clj found" nil t))))
+        (message "Waiting for swank ..%s.." timeout)
+        (sleep-for 1)
+        (decf timeout))
+      (let ((port (match-string 1)))
+        (if port
+          (progn
+            (goto-char (point-min))
+            (search-forward-regexp "Connection opened on local port +\\([0-9]+\\)")
+            (slime-connect "localhost" (match-string 1)))
+          (message "No swank found.."))))))
+
+(defun elein-run-task (task)
+  "Run 'lein TASK' using `compile' in the project root directory."
+  (interactive "sTask: ")
+  (elein-in-project-root (compile (concat "lein " task))))
+
+(defmacro elein-defun-run-task (task)
+  "Define shortcut function for `elein-run-task' with argument TASK."
+  `(defun ,(intern (concat "elein-" task)) ()
+     ,(concat "Run 'lein " task "' in the project root directory.")
+     (interactive)
+     (elein-run-task ,task)))
+
+;; define interactive elein-TASK commands for common tasks
+(dolist (task '(classpath
+                clean
+                compile
+                deps
+                help
+                install
+                jar
+                new
+                pom
+                repl
+                test
+                uberjar
+                upgrade
+                version))
+  (eval `(elein-defun-run-task ,(symbol-name task))))
+
+(provide 'elein)
+
+;;; elein.el ends here

--- a/elein.el
+++ b/elein.el
@@ -58,6 +58,16 @@
          (let ((default-directory ,dir)) ,body)
          (error "No leiningen project root found")))))
 
+(defun elein-list-tasks ()
+  (elein-in-project-root
+   (let ((output (shell-command-to-string "lein help"))
+         (result nil)
+         (offset 0))
+    (while (string-match "^  \\(.*\\)" output offset)
+      (setq result (cons (match-string 1 output) result))
+      (setq offset (match-end 0)))
+    (sort result (lambda (a b) (string< a b))))))
+
 (defun elein-swank ()
   "Lauch lein swank and connect slime to it."
   (interactive)
@@ -101,7 +111,7 @@
 
 (defun elein-run-task (task)
   "Run 'lein TASK' using `compile' in the project root directory."
-  (interactive "sTask: ")
+  (interactive (list (completing-read "Task: " (elein-list-tasks))))
   (elein-in-project-root (compile (concat "lein " task))))
 
 (defmacro elein-defun-run-task (task)

--- a/elein.el
+++ b/elein.el
@@ -60,14 +60,7 @@
 
 (defun elein-project-root ()
   "Look for project.clj file to find project root."
-  (let ((cwd default-directory)
-        (found nil)
-        (max 10))
-    (while (and (not found) (> max 0))
-      (if (file-exists-p (concat cwd "project.clj"))
-        (setq found cwd)
-        (setq cwd (concat cwd "../") max (- max 1))))
-    (and found (expand-file-name found))))
+  (locate-dominating-file default-directory "project.clj"))
 
 (defmacro elein-in-project-root (body)
   "Wrap BODY to make `default-directory' the project root."

--- a/elein.el
+++ b/elein.el
@@ -126,9 +126,13 @@
     (set-process-filter (get-buffer-process buffer)
                         (lambda (process output)
                           (with-current-buffer elein-swank-buffer-name (insert output))
+
                           (when (string-match "Connection opened on local port +\\([0-9]+\\)" output)
-                            (slime-connect "localhost" (match-string 1 output))
+                            (slime-set-inferior-process
+                             (slime-connect "localhost" (match-string 1 output))
+                             process)
                             (set-process-filter process nil))))
+
     (message "Starting swank..")))
 
 ;;;###autoload

--- a/elein.el
+++ b/elein.el
@@ -5,7 +5,7 @@
 ;; Author: R.W. van 't Veer
 ;; Created: 2 Aug 2010
 ;; Keywords: tools processes
-;; Version: 0.2
+;; Version: 0.2.1
 ;; URL: https://github.com/remvee/elein
 
 ;; This program is free software; you can redistribute it and/or

--- a/elein.el
+++ b/elein.el
@@ -80,6 +80,25 @@
             (slime-connect "localhost" (match-string 1)))
           (message "No swank found.."))))))
 
+(defun elein-kill-swank ()
+  "Kill swank process started by lein swank."
+  (interactive)
+  (let ((swank-process (get-buffer-process "*elein-swank*")))
+    (when swank-process
+      (ignore-errors (slime-quit-lisp))
+      (let ((timeout elein-swank-timeout))
+        (while (and (> timeout 0) (eql 'run (process-status swank-process)))
+          (message "Waiting for swank to die ..%s.." timeout)
+          (sleep-for 1)
+          (decf timeout))
+        (ignore-errors (kill-buffer "*elein-swank*"))))))
+
+(defun elein-reswank ()
+  "Kill current lisp, restart lein swank and connect slime to it."
+  (interactive)
+  (elein-kill-swank)
+  (elein-swank))
+
 (defun elein-run-task (task)
   "Run 'lein TASK' using `compile' in the project root directory."
   (interactive "sTask: ")

--- a/elein.el
+++ b/elein.el
@@ -12,12 +12,12 @@
 ;; modify it under the terms of the GNU General Public License
 ;; as published by the Free Software Foundation; either version 3
 ;; of the License, or (at your option) any later version.
-;; 
+;;
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
-;; 
+;;
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to the
 ;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
@@ -209,6 +209,7 @@ project."
 (dolist (task '(classpath
                 clean
                 compile
+                deploy
                 deps
                 help
                 install

--- a/elein.el
+++ b/elein.el
@@ -206,12 +206,9 @@ project."
                 help
                 install
                 jar
-                new
                 pom
-                repl
                 test
                 uberjar
-                upgrade
                 version))
   (eval `(elein-defun-run-task ,(symbol-name task))))
 

--- a/elein.el
+++ b/elein.el
@@ -69,10 +69,7 @@
   "Coding system used for slime network connections.
 Should match any :encoding specified in `elein-swank-options'.
 See also `slime-net-valid-coding-systems'."
-  :type (cons 'choice
-              (mapcar (lambda (x)
-                        (list 'const (car x)))
-                      slime-net-valid-coding-systems))
+  :type 'symbol
   :group 'elein)
 
 (defun elein-project-root ()


### PR DESCRIPTION
Because gensym is a function, not macro.
